### PR TITLE
Improve mio echo example memory usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # libuv-vs-rustmio
 Some Benchmark and testing around Libuv and Rust MIO libraries
+
+Prior to running the benchmark: `cd tcp_mio/ && cargo run`.
+
+Example benchmark: `go run bc.go localhost:8888 100 LICENSE`. This will run the benchmark with 100 connections using the contents of the LICENSE file as the data to echo.

--- a/tcp_mio/Cargo.lock
+++ b/tcp_mio/Cargo.lock
@@ -3,6 +3,7 @@ name = "tcp_mio"
 version = "0.1.0"
 dependencies = [
  "mio 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/tcp_mio/Cargo.toml
+++ b/tcp_mio/Cargo.toml
@@ -5,3 +5,4 @@ authors = ["Tigran Bayburtsyan <tigran@bayburtsyan.com>"]
 
 [dependencies]
 mio = "0.6"
+slab = "0.3.0"


### PR DESCRIPTION
- use a connection slab instead of a BTree to manage existing connections
- use a VecDeque instead of a LinkedList for the write queue